### PR TITLE
Make short clientid optional

### DIFF
--- a/google-plus-signin.js
+++ b/google-plus-signin.js
@@ -8,13 +8,16 @@
 
 angular.module('directive.g+signin', []).
   directive('googlePlusSignin', function () {
+  var ending = /\.apps\.googleusercontent\.com$/;
+
   return {
     restrict: 'E',
     template: '<span class="g-signin"></span>',
     replace: true,
     link: function (scope, element, attrs) {
+      attrs.clientid += (ending.test(attrs.clientid) ? '' : '.apps.googleusercontent.com');
 
-      attrs.$set('data-clientid', attrs.clientid + '.apps.googleusercontent.com');
+      attrs.$set('data-clientid', attrs.clientid);
 
       // Some default values, based on prior versions of this directive
       var defaults = {
@@ -40,13 +43,12 @@ angular.module('directive.g+signin', []).
       })();
     }
   };
-}).run(['$window','$rootScope',function($window,$rootScope) {
+}).run(['$window','$rootScope',function($window, $rootScope) {
   $window.signinCallback = function (authResult) {
-    if(authResult && authResult.access_token){
-      $rootScope.$broadcast('event:google-plus-signin-success',authResult);
-    }
-    else{
-      $rootScope.$broadcast('event:google-plus-signin-failure',authResult);
+    if (authResult && authResult.access_token){
+      $rootScope.$broadcast('event:google-plus-signin-success', authResult);
+    } else {
+      $rootScope.$broadcast('event:google-plus-signin-failure', authResult);
     }
   }; 
 }]);


### PR DESCRIPTION
Make so that the ending '.apps.googleusercontent.com' is optional in the clientid.

Believe it or not but I just troubleshot this kind of problem for an hour or so.

PR also contains some fairly minor convention unification - few spaces.
