### PR TITLE
Properly overwrite default values if explicitly provided.

### DIFF
--- a/google-plus-signin.js
+++ b/google-plus-signin.js
@@ -31,10 +31,10 @@ angular.module('directive.g+signin', []).
 
         defaults.clientid = attrs.clientid;
 
-        // Provide default values if not explicitly set
+        // Overwrite default values if explicitly set
         angular.forEach(Object.getOwnPropertyNames(defaults), function(propName) {
-          if (!attrs.hasOwnProperty(propName)) {
-            attrs.$set('data-' + propName, defaults[propName]);
+          if (attrs.hasOwnProperty(propName)) {
+            defaults[propName] = attrs[propName];
           }
         });
 


### PR DESCRIPTION
This patch will probably overwrite the default values with explicitly provided valuies. Without this patch overwriting any value, as e.g. `width` in the example below, won't work:

```
<google-plus-signin
    clientid="myclientid"
    language="en"
    width="iconOnly"></<google-plus-signin>
```

The existing code does update the attributes with the default values, but the attributes are actually never used since the defaults are passed directly to `gapi.signin.render`. This patch reverses this and now the defaults get overwritten with explicitly provided attributes.