### PR TITLE
Added state to passable params.

### DIFF
--- a/google-plus-signin.js
+++ b/google-plus-signin.js
@@ -27,6 +27,7 @@ angular.module('directive.g+signin', []).
           requestvisibleactions: 'http://schemas.google.com/AddActivity',
           scope: 'https://www.googleapis.com/auth/plus.login https://www.googleapis.com/auth/userinfo.email',
           width: 'wide',
+          state: ''
         };
 
         defaults.clientid = attrs.clientid;


### PR DESCRIPTION
I added state to the list of params g-signin attempts to respect.

See States:
https://developers.google.com/+/web/api/javascript#classes