### PR TITLE
Update google-plus-signin.js

### DIFF
--- a/google-plus-signin.js
+++ b/google-plus-signin.js
@@ -35,6 +35,7 @@ angular.module('directive.g+signin', []).
                   longtitle: false,
                   theme: 'dark',
                   autorender: true,
+                  access_type : online,
                   customtargetid: 'googlebutton'
               };
 


### PR DESCRIPTION
added access_type field to google-plus-signin.js so that access_type can be changed to offline overriding the defaults and refresh token can also be received from google for extending the time of access token. and fetch data when user is offline.
