### PR TITLE
Solved bug when autorender='false' and onsuccess

### DIFF
--- a/google-plus-signin.js
+++ b/google-plus-signin.js
@@ -43,7 +43,10 @@ angular.module('directive.g+signin', []).
               // Overwrite default values if explicitly set
               angular.forEach(Object.getOwnPropertyNames(defaults), function (propName) {
                   if (attrs.hasOwnProperty(propName)) {
-                      defaults[propName] = attrs[propName];
+                      if(propName == 'onsuccess' || propName == 'onfailure')
+                        defaults[propName] = window[attrs[propName]];
+                      else
+                        defaults[propName] = attrs[propName];
                   }
               });
               var isAutoRendering = (defaults.autorender !== undefined && (defaults.autorender === 'true' || defaults.autorender === true));


### PR DESCRIPTION
When you had autorender='false' and specified an onsuccess function, it was not called after a successful login.